### PR TITLE
fix(security): generate OTP with SecureRandom, uniform draw, zero-padded (A2)

### DIFF
--- a/keycloak/sms-provider/src/main/java/org/sunbird/keycloak/resetcredential/sms/KeycloakSmsAuthenticatorUtil.java
+++ b/keycloak/sms-provider/src/main/java/org/sunbird/keycloak/resetcredential/sms/KeycloakSmsAuthenticatorUtil.java
@@ -9,9 +9,9 @@ import org.sunbird.sms.provider.ISmsProvider;
 import org.sunbird.utils.JsonUtil;
 
 import java.io.File;
+import java.security.SecureRandom;
 import java.util.List;
 import java.util.Map;
-import java.util.Random;
 import java.util.stream.Collectors;
 
 /**
@@ -20,6 +20,8 @@ import java.util.stream.Collectors;
 public class KeycloakSmsAuthenticatorUtil {
 
     private static Logger logger = Logger.getLogger(KeycloakSmsAuthenticatorUtil.class);
+
+    private static final SecureRandom SECURE_RANDOM = new SecureRandom();
 
     public static String getAttributeValue(UserModel user, String attributeName) {
         String result = null;
@@ -119,14 +121,17 @@ public class KeycloakSmsAuthenticatorUtil {
     }
 
     static String getSmsCode(long nrOfDigits) {
-        if (nrOfDigits < 1) {
-            throw new RuntimeException("Number of digits must be bigger than 0");
+        if (nrOfDigits < 1 || nrOfDigits > 9) {
+            // 10^9 fits in an int; higher widths would need a long/BigInteger draw.
+            throw new IllegalArgumentException("Number of digits must be between 1 and 9");
         }
 
-        double maxValue = Math.pow(10.0, nrOfDigits); // 10 ^ nrOfDigits;
-        Random r = new Random();
-        long code = (long) (r.nextFloat() * maxValue);
-        return Long.toString(code);
+        // SecureRandom + uniform integer draw (not java.util.Random / nextFloat, which is a
+        // predictable LCG that under-samples the code space). Zero-pad so leading zeros are
+        // preserved and every OTP is exactly nrOfDigits long.
+        int bound = (int) Math.pow(10, nrOfDigits);
+        int code = SECURE_RANDOM.nextInt(bound);
+        return String.format("%0" + nrOfDigits + "d", code);
     }
 
     public static boolean validateTelephoneNumber(String telephoneNumber) {


### PR DESCRIPTION
## Summary
Fixes the predictable-OTP finding **A2 (HIGH)** in [`implementation-designs/sunbird-auth.md`](../../implementation-designs/sunbird-auth.md).

### The vulnerability
`KeycloakSmsAuthenticatorUtil.getSmsCode` generated the OTP with:
```java
double maxValue = Math.pow(10.0, nrOfDigits);
Random r = new Random();
long code = (long) (r.nextFloat() * maxValue);
return Long.toString(code);
```
Three compounding defects:
1. `java.util.Random` is a **time-seeded LCG** — not cryptographic, predictable from a couple of outputs.
2. `nextFloat()`'s ~24-bit mantissa can't uniformly address a `10^8` space → gaps/clustering, some codes unreachable.
3. `Long.toString(code)` **drops leading zeros**, shrinking effective length and leaking that the high digits were zero.

### The fix
- A shared `private static final SecureRandom`.
- Uniform `SECURE_RANDOM.nextInt(10^n)` draw.
- `String.format("%0Nd", code)` zero-padding so every OTP is exactly `nrOfDigits` long.
- Guard `nrOfDigits` to `1..9` (fits in `int`); throw `IllegalArgumentException` (still a `RuntimeException`, so existing catch sites are unaffected).

Pure utility change — no Keycloak SPI contract impact. `SecureRandom.nextInt` is non-blocking at OTP volumes.

## Verification
- `sms-provider` module **test-compiles under JDK 11** (exit 0; class recompiled).

## Scope / deferred
A1 (OTP expiry never enforced / no first-use invalidation), A3 (attempt lockout/rate-limit), and A4 (msg91 over cleartext HTTP, authkey in URL) are separate, higher-touch changes and get their own PRs.